### PR TITLE
REF: fall back to QLabel if no channel is associated with PyDMLabel

### DIFF
--- a/src/adl2pydm/output_handler.py
+++ b/src/adl2pydm/output_handler.py
@@ -191,7 +191,7 @@ class Widget2Pydm(object):
         brush = self.writer.writeOpenTag(propty, "brush", brushstyle=fill)
         self.write_color_element(brush, block.color, alpha="255")
 
-        if qw.attrib["class"] not in ("PyDMLabel",):
+        if qw.attrib["class"] not in ("PyDMLabel", "QLabel"):
             propty = self.writer.writeOpenProperty(qw, "penStyle", stdset="0")
             pen = dict(
                 solid = "Qt::SolidLine",
@@ -230,7 +230,13 @@ class Widget2Pydm(object):
         handler = self.pydm_widget_handlers.get(
             block.symbol, 
             self.write_block_default)
+
         cls = widget_info["pydm_widget"]
+        if cls == 'PyDMLabel' and not (block.contents.get('monitor') or
+                                       block.contents.get('control')):
+            # Fall back to QLabel, as there is no associated channel.
+            cls = 'QLabel'
+
         # if block.symbol.find("chart") >= 0:
         #     _z = 2
         # TODO: PyDMDrawingMMM (Line, Polygon, Oval, ...) need more decisions here 


### PR DESCRIPTION
This doesn't have to be accepted here, but it's one possible solution for a downstream typhos issue that may be agreeable.

In downstream Typhos, we have specific stylesheets for PyDMLabel, making the auto-converted AreaDetector screens look particularly bad:

![image](https://user-images.githubusercontent.com/5139267/83052668-7e72fd80-a004-11ea-9f60-2cd385323ebe.png)

With this fix, the channel-less PyDMLabel is recast to a `QLabel`:

![image](https://user-images.githubusercontent.com/5139267/83052875-c5f98980-a004-11ea-8f1f-d940bde3d053.png)

Separately - would you mind a PR that fixes trailing whitespace issues in the repository? My editor found and fixed hundreds automatically, making contributing a bit more difficult.