### PR TITLE
CI: add python 3.8 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@
 dist: bionic   # required for python >= 3.8
 language: python
 python:
+  - "2.7"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@
 #  https://docs.travis-ci.com/user/customizing-the-build#The-Build-Lifecycle
 #  https://docs.travis-ci.com/user/languages/python
 
-
-dist: xenial   # required for Python >= 3.7
+dist: bionic   # required for python >= 3.8
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
+  - "3.8"
   # - "nightly"
 
 before_script:


### PR DESCRIPTION
Testing on Python 2.7 is failing as the codebase uses a considerable amount of f-strings. Removed that and added Python 3.8.